### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ Report generation can be automated with gradle.
 Example:
 ```groovy
 task generateAllureReport(type: Exec) {
-    commandLine "allure generate build/allure-results -v ${allureVersion} -o build/reports/allure"
+    commandLine "allure", "generate", "build/allure-results", "-v", "${allureVersion}", "-o", "build/reports/allure"
 }
 test.finalizedBy(generateAllureReport)
 
 task openAllureReport(type: Exec) {
-    commandLine "allure report open -o build/reports/allure"
+    commandLine "allure", "report", "open", "-o", "build/reports/allure"
 }
 ```


### PR DESCRIPTION
The provided README.md was not accurate, as the gradle Exec task expects the arguments of the commandLine method as a list rather than a string. 